### PR TITLE
Fix While Loop Paced Function Resolution

### DIFF
--- a/src/rewriter.js
+++ b/src/rewriter.js
@@ -89,15 +89,6 @@ function whichWaitedReturn (item, entity) {
 }
 
 /**
-   * getPacedPromiseLine - Gets the await promise resolve line for paced code.
-   * @param {entity} entity - the entity triggering the method.
-   * @returns {string} - the promise resolve line string.
-   */
-function getPacedPromiseLine (entity) {
-  return `await new Promise(resolve => setTimeout(resolve, ${entity.pace}));`
-}
-
-/**
 * insertPaced - inserts a timed await line after any method that is on the list of paced methods.
 *
 * @param {string} item - a line of code.
@@ -106,7 +97,7 @@ function getPacedPromiseLine (entity) {
 * @return {string} - a modified line of code.
 */
 function insertPaced (item, entity) {
-  const code = `${item}\n${getPacedPromiseLine(entity)}`
+  const code = `${item}\n await new Promise(resolve => setTimeout(resolve, ${entity.pace}));`
   return entity.pace && isPaced(replaceUserStringWithBlanks(item), entity) ? code : item
 }
 
@@ -250,7 +241,6 @@ export default function rewrite (func, entity) {
 
     // counter for open parentheses.
     let eventedOpenParen = 0
-    let hasPacedCode = false
 
     code = code.map((item) => {
       const temp = item
@@ -260,7 +250,6 @@ export default function rewrite (func, entity) {
       if (isEvented(temp, entity) || eventedOpenParen) {
         eventedOpenParen += (countChar(replaceUserStringWithBlanks(temp), '(') - countChar(replaceUserStringWithBlanks(temp), ')'))
       } else {
-        if (isPaced(temp, entity)) hasPacedCode = true
         // a method can be one of the following but not more than one
         result === temp ? result = insertPaced(temp, entity) : null // more likely
         result === temp ? result = insertWaited(temp, entity) : null // less likely
@@ -271,21 +260,6 @@ export default function rewrite (func, entity) {
 
       return result
     })
-
-    // Always insert a paced promise resolve at the end of a while block if a while block is present and the function already includes paced code
-    // Without this the below code will cause a browser crash
-    /*
-      stage.whenFlag(function () {
-        while(true) {
-          if(stage.isKeyPressed('ArrowLeft')) {
-            sprite.changeX(-20);
-          }
-        }
-      });
-    */
-    const whileIndex = code.findIndex(line => line.match(/while\(.*\)/g))
-    if (whileIndex !== -1 && hasPacedCode) code.splice(code.length - 1 - whileIndex, 0, getPacedPromiseLine(entity))// insert before the while loop closes
-
     code = code.join('\n')
   }
 

--- a/src/rewriter.js
+++ b/src/rewriter.js
@@ -260,6 +260,27 @@ export default function rewrite (func, entity) {
 
       return result
     })
+
+    /*
+      stage.whenFlag(function () {
+        while(true) {
+          if(stage.isKeyPressed('ArrowLeft')) {
+            sprite.changeX(-20);
+          }
+        }
+      });
+    */
+
+    //Always force while loops to wait one event tick to stop the browser crashing
+    const whileIndex = code.findIndex(line => line.match(/while\(.*\)/g))
+    if (whileIndex !== -1) {
+      code.splice(
+        code.length-1-whileIndex, // insert before the while loop closes
+        0,
+        '\n await new Promise(resolve => setTimeout(resolve, 0));'
+      )
+    }
+
     code = code.join('\n')
   }
 

--- a/test/rewriter.test.js
+++ b/test/rewriter.test.js
@@ -321,35 +321,6 @@ describe('rewriter', () => {
       assert(f.toString().indexOf('await new Promise(resolve => setTimeout') === -1)
       sprite.pace = 33
     })
-
-    it('should add a paced promise resolve to the end of any while block if a paced function is present', () => {
-        let func, f, occurances
-
-        func = function () {
-            while(true) {
-                if(this.isKeyPressed('ArrowLeft')) {
-                    this.changeX(-20);
-                }
-            }
-        }
-
-        //checking if there are 2 occurances since the paced function itself should add a resolve and another should be added to the end of the while block aswell
-        f = rewrite(func, sprite)
-        occurances = f.toString().split('await new Promise(resolve => setTimeout').length-1;
-        assert(occurances === 2)
-
-        occurances = null; //reset
-
-        func = function () {
-            while(true) {
-                this.changeX(-20);
-            }
-        }
-
-        f = rewrite(func, sprite)
-        occurances = f.toString().split('await new Promise(resolve => setTimeout').length-1;
-        assert(occurances === 2)
-    })
   })
 
   describe('waited methods', () => {

--- a/test/rewriter.test.js
+++ b/test/rewriter.test.js
@@ -321,6 +321,35 @@ describe('rewriter', () => {
       assert(f.toString().indexOf('await new Promise(resolve => setTimeout') === -1)
       sprite.pace = 33
     })
+
+    it('should add a paced promise resolve to the end of any while block if a paced function is present', () => {
+        let func, f, occurances
+
+        func = function () {
+            while(true) {
+                if(this.isKeyPressed('ArrowLeft')) {
+                    this.changeX(-20);
+                }
+            }
+        }
+
+        //checking if there are 2 occurances since the paced function itself should add a resolve and another should be added to the end of the while block aswell
+        f = rewrite(func, sprite)
+        occurances = f.toString().split('await new Promise(resolve => setTimeout').length-1;
+        assert(occurances === 2)
+
+        occurances = null; //reset
+
+        func = function () {
+            while(true) {
+                this.changeX(-20);
+            }
+        }
+
+        f = rewrite(func, sprite)
+        occurances = f.toString().split('await new Promise(resolve => setTimeout').length-1;
+        assert(occurances === 2)
+    })
   })
 
   describe('waited methods', () => {

--- a/test/rewriter.test.js
+++ b/test/rewriter.test.js
@@ -321,6 +321,30 @@ describe('rewriter', () => {
       assert(f.toString().indexOf('await new Promise(resolve => setTimeout') === -1)
       sprite.pace = 33
     })
+    it('should add a paced promise resolve to the end of any while block', () => {
+        let func, f
+
+        func = function () {
+            while(true) {
+                if(this.isKeyPressed('ArrowLeft')) {
+                    this.changeX(-20);
+                }
+            }
+        }
+
+        //checking if there are 2 occurances since the paced function itself should add a resolve and another should be added to the end of the while block aswell
+        f = rewrite(func, sprite)
+        assert(f.toString().indexOf('await new Promise(resolve => setTimeout(resolve, 0));'))
+
+        func = function () {
+            while(true) {
+                this.changeX(-20);
+            }
+        }
+
+        f = rewrite(func, sprite)
+        assert(f.toString().indexOf('await new Promise(resolve => setTimeout(resolve, 0));'))
+    })
   })
 
   describe('waited methods', () => {


### PR DESCRIPTION
Always insert a paced promise resolve if a while block is present and the function already includes paced code. Currently if an if statement is placed within a while loop with no other paced function call after the if statement, a browser crash will happen. This is due to the function promise resolution code "await new Promise(resolve => setTimeout(resolve," not being reachable unless the if statement does not resolve to true and thus the function does not resolve either. Example code that will currently cause a crash is below.

The proposed code solution will work for any case where the function promise resolution cannot be reached inside the while loop.

Let me know if there is anything I have missed as I am not thart familiar with the code.

Example Crash:
```javascript
stage.whenFlag(function () {
    while(true) {
        if(stage.isKeyPressed('ArrowLeft')) {
            sprite.changeX(-20);
        }
    }
});
```

Generated Debug Code:
```javascript
(async function anonymous(
) {
    while(true) {
        if(stage.isKeyPressed('ArrowLeft')) {
            sprite.changeX(-20);
 await new Promise(resolve => setTimeout(resolve, 33));
        }
    }
})
```

Generated Debug Code With Proposed Change:
```javascript
(async function anonymous(
) {
    while(true) {
        if(stage.isKeyPressed('ArrowLeft')) {
            sprite.changeX(-20);
 await new Promise(resolve => setTimeout(resolve, 33));
        }

 await new Promise(resolve => setTimeout(resolve, 33));
    }
})
```